### PR TITLE
Горизонтальный скролл на маленьких экранах

### DIFF
--- a/style.css
+++ b/style.css
@@ -175,6 +175,7 @@ pre code {
   white-space: normal;
   tab-size: 2;
   max-height: 50rem;
+  box-sizing: border-box;
 }
 
 .code__line {


### PR DESCRIPTION
В блоках .code, padding вываливается за область просмотра.
