### PR TITLE
Изменение http на https для Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Список рекомендаций по неусложнению жизни себе и другим участникам проекта по вёрстке.">
 
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic|PT+Mono&subset=latin,cyrillic">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic|PT+Mono&subset=latin,cyrillic">
 
 </head>
 


### PR DESCRIPTION
Изменение http на https для Google Fonts, чтобы избежать предупреждения о смешанном содержимом.